### PR TITLE
fail on installation error

### DIFF
--- a/install
+++ b/install
@@ -20,6 +20,8 @@
 #  http://www.gnu.org/copyleft/gpl.html
 ################################################################################
 
+set -e
+
 FW_DIR="$DESTDIR/lib/firmware"
 
 mkdir -p $FW_DIR


### PR DESCRIPTION
This shell setting causes the script to fail if a command inside it fails.
So if the mkdir fails, ...
